### PR TITLE
Bugfix : missing 'await' in the rendering of the html template

### DIFF
--- a/lib/renderHtml.js
+++ b/lib/renderHtml.js
@@ -13,7 +13,7 @@ async function renderHtml(options) {
   const htmlFontsPath = path.relative(options.htmlDest, options.dest);
   // Styles embedded in the html file should use default CSS template and
   // have path to fonts that is relative to html file location.
-  const styles = renderCss({ ...options, cssFontPath: htmlFontsPath });
+  const styles = await renderCss({ ...options, cssFontPath: htmlFontsPath });
 
   return template({
     names: options.names,


### PR DESCRIPTION
Hello, 

I really like your fork of the archived repo **sunflowerdeath/webfonts-generator** because you're using async/await everywhere.

But one ```await``` is missing in the html rendering, ending up with a ```[Object Promise]``` in the style tag

For example, if you run ```test/manual.js```, the generated html ```temp/fontName.html``` is containing :
![Capture d’écran de 2024-03-14 09-12-24](https://github.com/furkot/webfonts-generator/assets/1260026/64a93100-b860-460d-95df-74ba6449e124)

This bug does not appear in your other repo **furkot/icon-fonts** because it uses its own custom handlebars template.

I'm hoping I'm clear enough (english is not my native language) and I hope it helps :heart: 